### PR TITLE
fix: windows 下 fast-glob 无法匹配 sdk 文件

### DIFF
--- a/packages/vscode/src/sdk/sdk-analyzer.ts
+++ b/packages/vscode/src/sdk/sdk-analyzer.ts
@@ -148,9 +148,9 @@ export class SdkAnalyzer {
         // '/Users/naily/OpenHarmony/10/lib.decorators.legacy.d.ts',
         // '/Users/naily/OpenHarmony/10/lib.es5.d.ts',
         ...fg.sync([
-          vscode.Uri.joinPath(etsComponentPath, '**', '*.d.ts').fsPath,
-          vscode.Uri.joinPath(etsComponentPath, '**', '*.d.ets').fsPath,
-          vscode.Uri.joinPath(etsLoaderPath, 'declarations', '**', 'global.d.ts').fsPath,
+          fg.convertPathToPattern(vscode.Uri.joinPath(etsComponentPath, '**', '*.d.ts').fsPath),
+          fg.convertPathToPattern(vscode.Uri.joinPath(etsComponentPath, '**', '*.d.ets').fsPath),
+          fg.convertPathToPattern(vscode.Uri.joinPath(etsLoaderPath, 'declarations', '**', 'global.d.ts').fsPath),
         ], { onlyFiles: true, absolute: true }),
       ].filter(Boolean) as string[],
       typeRoots: [


### PR DESCRIPTION
windows 下使用 fast-glob 匹配文件需要转换