### PR TITLE
fix: __dirname 获取方式在 windows 上异常

### DIFF
--- a/packages/vscode/scripts/reflect-fixer.mts
+++ b/packages/vscode/scripts/reflect-fixer.mts
@@ -2,8 +2,9 @@ import fs from 'node:fs'
 import path from 'node:path'
 import MagicString from 'magic-string'
 import { parseAndWalk } from 'oxc-walker'
+import { fileURLToPath } from "node:url";
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const distFilePath = path.join(__dirname, '../dist/client.js')
 const content = fs.readFileSync(distFilePath, 'utf-8')


### PR DESCRIPTION
mjs 中用 new URL 获取 __dirname windows 会变成 /D:/arkTS/packages/vscode/scripts，前面多了一个斜杠，用 fileURLToPath  进行转换