### PR TITLE
修复：改进 Translator 类的本地化文件处理并确保回退到英文本地化

### DIFF
--- a/packages/vscode/src/translate.ts
+++ b/packages/vscode/src/translate.ts
@@ -28,7 +28,8 @@ export class Translator {
     this.localeFiles = fs.readdirSync(this.localeFolder)
       .filter(file => file.endsWith('.json') && file.startsWith('package.nls'))
       .map((fileName) => {
-        const fileLocale = fileName.replace('package.nls.', '').replace('.json', '')
+        const match = fileName.match(/^package\.nls(?:\.([^.]+))?\.json$/)
+        const fileLocale = (match?.[1] || 'en').toLowerCase()
         const fileContent = JSON.parse(fs.readFileSync(path.join(this.localeFolder, fileName), 'utf-8'))
 
         return {
@@ -39,8 +40,9 @@ export class Translator {
   }
 
   public t<TKey extends string>(key: TKey, options: TOptions = {}): string {
-    const locale = vscode.env.language
-    const localeFile = this.localeFiles.find(file => file.locale === locale)
+    const locale = vscode.env.language.toLowerCase()
+    // Try to match the current locale; if not found, fall back to default English locale
+    const localeFile = this.localeFiles.find(file => file.locale === locale) ?? this.localeFiles.find(file => file.locale === 'en')
     if (!localeFile)
       return key
     const value = get(localeFile.content, key)


### PR DESCRIPTION
在 `Translator` 类中存在本地化文件处理的缺陷：

1. **文件名解析不够健壮**：原有的字符串替换方法无法正确处理 `package.nls.json`（默认英文）文件
2. **缺少回退机制**：当用户的语言环境不受支持时，没有回退到英文本地化的机制
3. **大小写敏感问题**：语言匹配时没有考虑大小写统一性

当前改进了 `Translator` 的实现确保不支持的语言能回退到英文本地化

> 建议使用官方的 `@vscode/i10n`(https://www.npmjs.com/package/@vscode/l10n)