### PR TITLE
fix: add check to prevent duplicate Reflect fix application

### DIFF
--- a/packages/vscode/scripts/reflect-fixer.mts
+++ b/packages/vscode/scripts/reflect-fixer.mts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import MagicString from 'magic-string'
 import { parseAndWalk } from 'oxc-walker'

--- a/packages/vscode/scripts/reflect-fixer.mts
+++ b/packages/vscode/scripts/reflect-fixer.mts
@@ -8,6 +8,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const distFilePath = path.join(__dirname, '../dist/client.js')
 const content = fs.readFileSync(distFilePath, 'utf-8')
+
+// Check if the fix already exists to avoid duplicate additions
+if (content.includes('require_chunk.__toESM(require_Reflect());')) {
+  console.log('Reflect fix already applied, skipping...')
+  process.exit(0)
+}
+
 const ms = new MagicString(content, {
   filename: distFilePath,
 })


### PR DESCRIPTION
This pull request adds a safeguard to the `reflect-fixer.mts` script to prevent duplicate application of the Reflect fix. If the fix has already been applied to `client.js`, the script will now detect this and exit early.

* Script improvement:
  * Added a check to see if `require_chunk.__toESM(require_Reflect());` is already present in the `dist/client.js` file, and if so, the script logs a message and exits to avoid redundant modifications.