### PR TITLE
fix: 修复struct Hover、CallExpression Hover的高亮问题，替换typescript语言为ets语言实现正确的高亮

### DIFF
--- a/.changeset/icy-things-float.md
+++ b/.changeset/icy-things-float.md
@@ -1,0 +1,6 @@
+---
+"@arkts/language-server": patch
+"vscode-naily-ets": patch
+---
+
+fix: 修复 struct Hover、CallExpression Hover 的高亮问题，替换 typescript 语言为 ets 语言实现正确的高亮 (#179)

--- a/packages/language-server/src/patches/patch-semantic.ts
+++ b/packages/language-server/src/patches/patch-semantic.ts
@@ -30,6 +30,7 @@ export function patchSemantic(typescriptServices: LanguageServicePlugin[]): void
         if (!ets.isAnnotationDeclaration(node)) return node.forEachChild(walk)
         if (currentPositionOffset >= node.getStart(sourceFile) && currentPositionOffset <= node.getEnd()) {
           foundAnnotationDeclaration = node
+          return
         }
         return node.forEachChild(walk)
       })
@@ -70,6 +71,7 @@ export function patchSemantic(typescriptServices: LanguageServicePlugin[]): void
         if (!ets.isAnnotation(node)) return node.forEachChild(walk)
         if (currentPositionOffset >= node.getStart(sourceFile) && currentPositionOffset <= node.getEnd()) {
           foundDecorator = node
+          return
         }
         return node.forEachChild(walk)
       })
@@ -105,6 +107,7 @@ export function patchSemantic(typescriptServices: LanguageServicePlugin[]): void
         if (!ets.isStructDeclaration(node)) return node.forEachChild(walk)
         if (currentPositionOffset >= node.getStart(sourceFile) && currentPositionOffset <= node.getEnd()) {
           foundStructDeclaration = node
+          return
         }
         return node.forEachChild(walk)
       })
@@ -143,6 +146,7 @@ export function patchSemantic(typescriptServices: LanguageServicePlugin[]): void
         if (!ets.isCallExpression(node)) return node.forEachChild(walk)
         if (currentPositionOffset >= node.getStart(sourceFile) && currentPositionOffset <= node.getEnd()) {
           foundCallExpression = node
+          return
         }
         return node.forEachChild(walk)
       })

--- a/packages/language-server/test/Index.ets
+++ b/packages/language-server/test/Index.ets
@@ -1,6 +1,6 @@
 @Entry
 @Component
-struct Index {
+export struct Index {
   @State message: string = 'Hello World'
 
   build() {

--- a/packages/language-server/test/test-resource-jump.ets
+++ b/packages/language-server/test/test-resource-jump.ets
@@ -3,7 +3,7 @@
 
 @Entry
 @Component
-struct TestPage {
+export struct TestPage {
   build() {
     Column() {
       Text('Hello World')
@@ -21,9 +21,6 @@ struct TestPage {
       // 测试诊断功能：下面的资源引用不存在，应该显示错误/警告
       Text($r('app.string.nonexistent_string'))  // 不存在的资源
         .fontColor($r('app.color.nonexistent_color'))  // 不存在的颜色
-      
-      // 测试无效格式
-      Text($r('invalid.format'))  // 无效的资源引用格式
     }
     .width('100%')
     .height('100%')

--- a/sample/entry/src/main/ets/pages/Index.ets
+++ b/sample/entry/src/main/ets/pages/Index.ets
@@ -20,15 +20,16 @@ class MyLazyDataSource implements IDataSource {
 }
 
 @interface MyAnnotation {
-  value: string = "hello world"
+  hello: string = "world"
 }
 
 @MyAnnotation
 class MyClass {}
 
+
 @Entry
 @Component
-struct Index {
+export struct Index {
   @State
   message: string = 'Hello World';
   testESObject: ESObject = 'Hello ESObject';


### PR DESCRIPTION
<img width="628" height="260" alt="image" src="https://github.com/user-attachments/assets/e662087d-faad-4e98-93bd-5d8a97befefa" />

<img width="638" height="232" alt="image" src="https://github.com/user-attachments/assets/de72d726-6cc9-41b1-b07b-d1578e14b860" />
