### PR TITLE
feat(vscode): Add a help button in the language server error dialog box

### DIFF
--- a/packages/vscode/package.nls.json
+++ b/packages/vscode/package.nls.json
@@ -107,6 +107,7 @@
   "sdk.error.downloadOrChoiceSdkPath": "Download or choose a OpenHarmony SDK path",
   "sdk.error.languageServerError": "ArkTS Language Server Start Failed, please try to restart the IDE or check the OpenHarmony SDK path is correct. Error detail: {0}",
   "sdk.error.validSdkPath": "OpenHarmony SDK path is not set in global IDE configuration and local workspace local.properties file, the ETS Language Server will not work properly.",
+  "sdk.error.helpLabel": "Help",
   "sdk.guess.install.no": "No",
   "sdk.guess.install.title": "The current workspace likely use OpenHarmony SDK {0}, are you want to install this SDK?",
   "sdk.guess.install.yes": "Yes",

--- a/packages/vscode/package.nls.zh-cn.json
+++ b/packages/vscode/package.nls.zh-cn.json
@@ -107,6 +107,7 @@
   "sdk.error.downloadOrChoiceSdkPath": "下载或选择一个 OpenHarmony SDK 路径",
   "sdk.error.languageServerError": "ArkTS 语言服务器启动失败, 请尝试重启 IDE 或检查 OpenHarmony SDK 路径是否正确。错误详情: {0}",
   "sdk.error.validSdkPath": "OpenHarmony SDK 路径未设置在全局 IDE 配置和本地工作区 local.properties 文件中，ETS 语言服务器可能将无法正常工作。",
+  "sdk.error.helpLabel": "帮助",
   "sdk.guess.install.no": "否",
   "sdk.guess.install.title": "当前工作区可能使用 OpenHarmony SDK {0}，您是否想要安装此 SDK？",
   "sdk.guess.install.yes": "是",

--- a/packages/vscode/src/context/server-context.ts
+++ b/packages/vscode/src/context/server-context.ts
@@ -46,7 +46,7 @@ export abstract class LanguageServerContext extends AbstractWatcher implements I
     const downloadOrChoiceSdkPath = this.translator.t('sdk.error.downloadOrChoiceSdkPath')
     const helpLabel = this.translator.t('sdk.error.helpLabel')
     const detail = this.errorToString(error)
-    
+
     // 循环显示对话框，直到用户选择操作
     let result: string | undefined
     do {

--- a/packages/vscode/src/context/server-context.ts
+++ b/packages/vscode/src/context/server-context.ts
@@ -44,13 +44,28 @@ export abstract class LanguageServerContext extends AbstractWatcher implements I
     console.error(error)
     const choiceSdkPath = this.translator.t('sdk.error.choiceSdkPathMasually')
     const downloadOrChoiceSdkPath = this.translator.t('sdk.error.downloadOrChoiceSdkPath')
+    const helpLabel = this.translator.t('sdk.error.helpLabel')
     const detail = this.errorToString(error)
-    const result = await vscode.window.showWarningMessage(
-      'ArkTS Language Server Warning',
-      { modal: true, detail },
-      choiceSdkPath,
-      downloadOrChoiceSdkPath,
-    )
+    
+    // 循环显示对话框，直到用户选择操作
+    let result: string | undefined
+    do {
+      result = await vscode.window.showWarningMessage(
+        'ArkTS Language Server Warning',
+        { modal: true, detail },
+        choiceSdkPath,
+        downloadOrChoiceSdkPath,
+        helpLabel,
+      )
+
+      if (result === helpLabel) {
+        // 打开帮助文档，但不关闭对话框
+        const helpUrl = vscode.Uri.parse('https://arkcode.dev/arkts/install/#方法一-选择自带在-deveco-studio-中的-sdk-推荐')
+        await vscode.env.openExternal(helpUrl)
+        // 继续循环，重新显示对话框
+        result = undefined
+      }
+    } while (result === undefined)
 
     if (result === choiceSdkPath) {
       const [sdkPath] = await vscode.window.showOpenDialog({


### PR DESCRIPTION
- Add a "Help" button in the warning dialog box when the language server fails to start